### PR TITLE
ci: use API token in pypi reusable workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   deploy:
@@ -28,3 +27,5 @@ jobs:
           pip install build
           python -m build
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
### Notes
Pypi [Trusted Publishing](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing) is not supported in reusable workflows.  This PR reverts to token-based pypi publishing.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [ ] Code changes are compact and well-structured to facilitate easy review
- [ ] Changes are documented in the README.md and other relevant documentation pages
- [ ] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [ ] PR contains tests that cover all new code and the code has been manual tested
- [ ] All new dependencies are declared (if any), and no unnecessary libraries are added
- [ ] Performance impacts (if any) of the changes are evaluated and documented
- [ ] Security implications of the changes (if any) are reviewed and addressed
- [ ] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
